### PR TITLE
Changed the compute nodes to a type with EFA.

### DIFF
--- a/python/src/wrfcloud/aws/pcluster.py
+++ b/python/src/wrfcloud/aws/pcluster.py
@@ -34,7 +34,7 @@ class WrfCloudCluster:
         self.region = region or 'us-east-2'
         self.profile = profile or 'wrfcloud'
         self.subnet = subnet or 'subnet-067bf9400b5ca5833'
-        self.ami = ami or 'ami-0af68375a8c4f522e'
+        self.ami = ami or 'ami-03a9590b044f61d80'
         self.cluster_config = cluster_config or 'aws/resources/cluster.wrfcloud.yaml'
         self.cf_client = None
 

--- a/python/src/wrfcloud/aws/resources/cf_imagebuilder_wrf_intel.yaml
+++ b/python/src/wrfcloud/aws/resources/cf_imagebuilder_wrf_intel.yaml
@@ -31,7 +31,7 @@ Resources:
                     - yum -y install intel-oneapi-common-licensing
                     - yum -y install intel-oneapi-libdpstd-devel intel-oneapi-itac
                     - yum -y install intel-hpckit
-                    - yum -y install gcc gcc-c++ gcc-gfortran m4 curl-devel git cmake pkgconfig expat-devel libX11-devel libXmu-devel Xaw3d-devel libXaw-devel
+                    - yum -y install gcc gcc-c++ gcc-gfortran m4 curl-devel git cmake pkgconfig expat-devel libX11-devel libXmu-devel Xaw3d-devel libXaw-devel make openssl-devel bzip2-devel libffi-devel sqlite-devel
 
               - name: configure_bash
                 action: ExecuteBash
@@ -245,6 +245,33 @@ Resources:
                     - ./configure --prefix=/opt/netcdf --with-udunits2_incdir=${UDUNITS}/include  --with-udunits2_libdir=${UDUNITS}/lib --with-png_incdir=${LIBPNG}/include --with-png_libdir=${LIBPNG}/lib 2>&1 | tee configure.log
                     - make -j 4 install 2>&1 | tee build.log
                     - echo 'X11Forwarding yes' | tee -a /etc/ssh/sshd_config
+
+              - name: python39
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - source /etc/bashrc
+                    - mkdir -p /opt/src
+                    - cd /opt/src
+                    - wget https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz
+                    - tar -xzf Python-3.9.13.tgz
+                    - cd Python-3.9.13
+                    - unset CPP CC_FOR_BUILD CPP_FOR_BUILD
+                    - export CC=gcc
+                    - ./configure --prefix=/opt/python --enable-optimizations --with-openssl=/usr --enable-loadable-sqlite-extensions
+                    - make -j 4 install
+                    - echo 'export PYTHON39=/opt/python' | tee -a /etc/bashrc
+                    - echo 'export PATH=${PYTHON39}/bin:${PATH}' | tee -a /etc/bashrc
+
+              - name: wrfcloud
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - source /etc/bashrc
+                    - mkdir -p /opt/src
+                    - cd /opt/src
+                    - git clone https://github.com/NCAR/wrfcloud
+                    - pip3 install wrfcloud/python/src
 
               - name: build-wrf
                 action: ExecuteBash

--- a/python/src/wrfcloud/aws/resources/cluster.wrfcloud.yaml
+++ b/python/src/wrfcloud/aws/resources/cluster.wrfcloud.yaml
@@ -25,10 +25,10 @@ Scheduling:
     Image:
       CustomAmi: __AMI_ID__
     ComputeResources:
-    - Name: c6i
-      InstanceType: c6i.2xlarge  # 8-cores 16-gb-memory
+    - Name: hpc6a
+      InstanceType: hpc6a.48xlarge  # 96-cores 384-gb-memory $2.88/hr us-east-2 only
       Efa:
-        Enabled: false
+        Enabled: true
       MinCount: 0
       MaxCount: 1
     Networking:


### PR DESCRIPTION
Updated the ImageBuilder to install Python 3.9 and wrfcloud. Rebuilt the AMI and start clusters with the new image.

## Pull Request Testing ##
There are a new set of testing instructions at the top of [this document](https://docs.google.com/document/d/1cAxPvjCIZZVl2qbu3w78MVbJnM4edLKn1-yKcG72dP4/edit).

You should also be able to submit jobs to the slurm queue and get those to run as well.  The compute nodes are 96-core with a current limit of 1.