### PR TITLE
Feature #172 improve wind vector zoom updates

### DIFF
--- a/web/src/app/client-api.ts
+++ b/web/src/app/client-api.ts
@@ -898,7 +898,8 @@ export interface WrfLayer
   time_step: number;
   dt: number;
   plot_type: string;
-  zoom: number|undefined;
+  data_spacing: number|undefined;
+  display_spacing: number|undefined;
   handleZoomChange: Function;
 }
 


### PR DESCRIPTION
Closes #172 

## Expected Differences ##

- [X] Do these changes modify the system output in any way? **[Yes]**</br>

The wind vector spacing now updates more intelligently based on the current projection and data spacing when the zoom/projection changes.

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Started angular to view local changes for job [W146C654FDD](https://app.wrfcloud.com/view/W146C654FDD) and compared wind vector spacing to version on app.wrfcloud.com

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Start angular and view wind vector products for a few recent WRF runs with different domains. Zoom in and out of the display and confirm that spacing of vectors is satisfactory.

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
None needed as this was just a slight improvement to previous work.

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by **5/23/2023**.</br>

## Pull Request Checklist ##
- [X] Review the source issue metadata (labels, project, and milestone).
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Project**
Select: **Milestone** as the version that will include these changes
Select: **Development** to link to the original development issue.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
