### PR TITLE
Feature #188 restrict dates in forecast selector

### DIFF
--- a/web/src/app/launch-wrf/launch-wrf.component.html
+++ b/web/src/app/launch-wrf/launch-wrf.component.html
@@ -24,7 +24,7 @@
   <div class="launch-input-container">
     <mat-form-field appearance="fill">
       <mat-label>Cycle Date</mat-label>
-      <input matInput [matDatepicker]="picker" [(ngModel)]="start_time">
+      <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="picker" [(ngModel)]="start_time">
       <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-datepicker #picker></mat-datepicker>
     </mat-form-field>

--- a/web/src/app/launch-wrf/launch-wrf.component.ts
+++ b/web/src/app/launch-wrf/launch-wrf.component.ts
@@ -90,7 +90,7 @@ export class LaunchWrfComponent implements OnInit
     const next_day = moment().utc().add(1, 'days').startOf('day').seconds(1);
 
     /* update these dates when next UTC date starts */
-    setTimeout(this.refreshDateRange.bind(this), next_day.diff(this.maxDate, 'seconds'));
+    setTimeout(this.refreshDateRange.bind(this), next_day.diff(this.maxDate));
   }
 
 

--- a/web/src/app/launch-wrf/launch-wrf.component.ts
+++ b/web/src/app/launch-wrf/launch-wrf.component.ts
@@ -65,14 +65,32 @@ export class LaunchWrfComponent implements OnInit
   /* Latest date that can be selected */
   public maxDate: Date;
 
-
   constructor()
   {
     this.refreshModelConfigurations();
-    // earliest date to select is Feb. 26, 2021
+
+    /* GRIB data are not available before Feb. 26, 2021, so this is the earliest time */
     this.minDate = new Date("2021-02-26");
-    // latest date to select is today
-    this.maxDate = new Date();
+
+    /* latest date to select is today */
+    this.maxDate = moment().utc().toDate();
+
+    this.refreshDateRange();
+  }
+
+  /**
+   * Update the valid date range of the cycle date
+   */
+  private refreshDateRange(): void
+  {
+    /* latest date to select is today */
+    this.maxDate = moment().utc().toDate();
+
+    /* get 1 second into the next UTC day */
+    const next_day = moment().utc().add(1, 'days').startOf('day').seconds(1);
+
+    /* update these dates when next UTC date starts */
+    setTimeout(this.refreshDateRange.bind(this), next_day.diff(this.maxDate, 'seconds'));
   }
 
 

--- a/web/src/app/launch-wrf/launch-wrf.component.ts
+++ b/web/src/app/launch-wrf/launch-wrf.component.ts
@@ -59,10 +59,20 @@ export class LaunchWrfComponent implements OnInit
   /* list of valid model configuration options */
   public modelConfigOptions: Array<string> = [];
 
+  /* Earliest date that can be selected */
+  public minDate: Date;
+
+  /* Latest date that can be selected */
+  public maxDate: Date;
+
 
   constructor()
   {
     this.refreshModelConfigurations();
+    // earliest date to select is Feb. 26, 2021
+    this.minDate = new Date("2021-02-26");
+    // latest date to select is today
+    this.maxDate = new Date();
   }
 
 


### PR DESCRIPTION
Closes #188 

Restrict the dates that can be selected for Cycle Date in the Launch WRF page to no later than today's date and not before Feb. 26, 2021 because the input data is not available in S3 before that date.

NOTE: WebStorm reports an error when the min/max values are added to the HTML. Apparently this is a bug as the syntax works as expected (see [this comment](https://github.com/angular/components/issues/24572#issuecomment-1083633904)).

## Expected Differences ##

- [X] Do these changes modify the system output in any way? **[No]**</br>

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Started angular locally and confirmed that the date selector is properly restricted.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Test locally if desired

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by **6/13/2023**.</br>

## Pull Request Checklist ##
- [X] Review the source issue metadata (labels, project, and milestone).
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Project**
Select: **Milestone** as the version that will include these changes
Select: **Development** to link to the original development issue.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
